### PR TITLE
Another pull request

### DIFF
--- a/lib/AnyEvent/Open3/Simple.pm
+++ b/lib/AnyEvent/Open3/Simple.pm
@@ -5,6 +5,7 @@ use warnings;
 use v5.10;
 use AnyEvent;
 use IPC::Open3 qw( open3 );
+use Scalar::Util qw( reftype );
 use Symbol qw( gensym );
 use AnyEvent::Open3::Simple::Process;
 
@@ -109,7 +110,7 @@ sub new
 {
   state $default_handler = sub { };
   my $class = shift;
-  my $args = ref $_[0] eq 'HASH' ? shift : { @_ };
+  my $args = reftype($_[0]) eq 'HASH' ? shift : { @_ };
   my %self;
   $self{$_} = $args->{$_} // $default_handler for qw( on_stdout on_stderr on_start on_exit on_signal on_fail on_error );
   bless \%self, $class;


### PR DESCRIPTION
Also, this is just my own recommendation - changing to reftype instead of ref is much more robust in the case that the user passes something like a ref to a tied hash, or just some sort of object that they _want_ treated like a hash.
