### PR TITLE
v0.80

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Perl_5
 copyright_holder = Graham Ollis
 copyright_year   = 2012
 
-version = 0.79
+version = 0.80
 
 [@Author::Plicease]
 release_tests = 1


### PR DESCRIPTION
```
  - add optional callback to run() for passing data to sub-processes
```
