### PR TITLE
add missing semicolons in tests

### DIFF
--- a/t/anyevent_open3_simple__print.t
+++ b/t/anyevent_open3_simple__print.t
@@ -18,7 +18,7 @@ my $dir = tempdir( CLEANUP => 1 );
 my $fh;
 open($fh, '>', File::Spec->catfile($dir, 'child.pl'));
 print $fh join "\n", "#!$^X",
-                     'use File::Spec',
+                     'use File::Spec;',
                      "open(\$out, '>', File::Spec->catfile('$dir', 'child.out'));",
                      'while(<STDIN>) {',
                      '  print $out $_',

--- a/t/anyevent_open3_simple__stdin.t
+++ b/t/anyevent_open3_simple__stdin.t
@@ -12,7 +12,7 @@ my $dir = tempdir( CLEANUP => 1 );
 my $fh;
 open($fh, '>', File::Spec->catfile($dir, 'child.pl'));
 print $fh "#!$^X\n";
-print $fh 'use File::Spec', "\n";
+print $fh 'use File::Spec;', "\n";
 print $fh "open(\$out, '>', File::Spec->catfile('$dir', 'child.out'));", "\n";
 print $fh 'while(<STDIN>) {', "\n";
 print $fh '  print $out $_', "\n";


### PR DESCRIPTION
The tests were loading File::Spec, but were missing the trailing semicolons. This resulted in the return value from the open call being passed in to File::Spec->import. Perl would then ignore that call to a nonexistent import. Future versions of perl are intending to make calls to undefined import methods with arguments an error.